### PR TITLE
Disable double tap zoom on mobile envrionment

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -51,6 +51,8 @@ body {
   position: relative;
   width: 100%;
   height: 100%;
+
+  touch-action: manipulation;
 }
 
 body {


### PR DESCRIPTION
Disable double tap zoom on mobile environment.

Tested on Safari (iOS 15.7) and Chrome (v106.0.5249.79, Android 12).

Close #1 