### PR TITLE
Improve UI in low res screens and update keyboard/wordle guess layout

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -21,6 +21,6 @@
 
 <Nav />
 
-<main class="tw-container tw-mx-auto tw-pt-6 tw-pb-1">
+<main class="tw-w-full tw-mx-auto tw-py-1 tw-h-[calc(100%-var(--nav-height))]">
   <Router {routes} />
 </main>

--- a/src/Nav.svelte
+++ b/src/Nav.svelte
@@ -11,15 +11,15 @@
 </script>
 
 <nav
-  class="tw-inline-flex tw-justify-between tw-gap-4 tw-w-full tw-px-6 tw-py-2 tw-border-b tw-border-solid tw-border-app-text-secondary"
+  class="tw-inline-flex tw-justify-between tw-gap-3 md:tw-gap-4 tw-w-full tw-h-[var(--nav-height)] tw-px-3 md:tw-px-6 tw-py-2 tw-border-b tw-border-solid tw-border-app-text-secondary"
 >
-  <div class="tw-inline-flex tw-gap-4">
+  <div class="tw-inline-flex tw-gap-3 md:tw-gap-4">
     <LinkButton url={ROUTES.home} useRouter underline={false}>
       <AppIcon width={32} />
       <span class="tw-ml-2 tw-font-medium">{APP_NAME}</span>
     </LinkButton>
   </div>
-  <div class="tw-inline-flex tw-gap-4">
+  <div class="tw-inline-flex tw-gap-3 md:tw-gap-4">
     {#if !PRODUCTION}
       <LinkButton url={ROUTES.fontViewer} useRouter>
         <FontIcon />

--- a/src/app.css
+++ b/src/app.css
@@ -3,6 +3,10 @@
 @tailwind utilities;
 
 :root {
+  --nav-height: 48px;
+}
+
+:root {
   --background-color: #fff;
   --text-color: #333;
   --text-color-secondary: #a8a8a8;

--- a/src/components/nav/Help.svelte
+++ b/src/components/nav/Help.svelte
@@ -107,7 +107,7 @@
     <p>단어를 입력하면 정답과 비교하여 자모 혹은 입력 칸의 색이 바뀌어요.</p>
   </div>
 
-  <div class="tw-mt-7 tw-text-center ">
+  <div class="tw-mt-5 tw-text-center">
     <Guess guess={word1} answerLength={word1.guess.length} />
   </div>
 
@@ -130,7 +130,7 @@
     </li>
   </ul>
 
-  <div class="tw-mt-7 tw-text-center">
+  <div class="tw-mt-5 tw-text-center">
     <Guess guess={word2} answerLength={word2.guess.length} />
   </div>
 
@@ -144,7 +144,7 @@
     </li>
   </ul>
 
-  <div class="tw-mt-7 tw-w-full tw-inline-flex tw-justify-evenly tw-gap-4">
+  <div class="tw-mt-5 tw-w-full tw-inline-flex tw-justify-evenly tw-gap-4">
     <Guess guess={word3} answerLength={word3.guess.length} />
     <Guess guess={word4} answerLength={word4.guess.length} />
     <Guess guess={word5} answerLength={word5.guess.length} />
@@ -185,7 +185,7 @@
     </li>
   </ul>
 
-  <div class="tw-mt-7 tw-text-sm tw-text-app-text-secondary">
+  <div class="tw-mt-5 tw-text-sm tw-text-app-text-secondary">
     오리지널 워들(영문)은
     <a
       href="https://www.nytimes.com/games/wordle/index.html"

--- a/src/components/wordle/Game.svelte
+++ b/src/components/wordle/Game.svelte
@@ -56,32 +56,36 @@
   <Alert />
 </div>
 
-<div class="tw-container tw-mb-12">
-  {#each { length: $ui.nRows } as _, rowIndex}
-    <div class="tw-mb-6">
-      {#each { length: $game.nGuesses } as _, guessIndex}
-        <div
-          class="tw-flex tw-flex-nowrap tw-justify-center tw-gap-4 tw-mx-2 tw-my-1"
-        >
-          {#each { length: ui.nWordlesAtRow(rowIndex) } as _, colIndex}
-            {@const wordleIndex = $ui.nWordlesPerRow * rowIndex + colIndex}
-            {@const wordle = $game.wordleData[wordleIndex]}
+<div
+  class="tw-w-full tw-h-full tw-inline-flex tw-flex-col tw-overflow-y-hidden"
+>
+  <div class="tw-my-auto tw-py-1.5 md:tw-py-3 tw-overflow-y-auto">
+    {#each { length: $ui.nRows } as _, rowIndex}
+      <div class={$ui.nRows > 1 ? 'tw-mb-4 md:tw-mb-6' : ''}>
+        {#each { length: $game.nGuesses } as _, guessIndex}
+          <div
+            class="tw-flex tw-flex-nowrap tw-justify-center tw-gap-4 tw-mx-2 tw-my-1"
+          >
+            {#each { length: ui.nWordlesAtRow(rowIndex) } as _, colIndex}
+              {@const wordleIndex = $ui.nWordlesPerRow * rowIndex + colIndex}
+              {@const wordle = $game.wordleData[wordleIndex]}
 
-            {#if guessIndex < wordle.guessResults.length}
-              <Guess
-                guess={wordle.guessResults[guessIndex]}
-                answerLength={$game.answerLength}
-              />
-            {:else if wordle.status === 'playing' && guessIndex === wordle.guessResults.length}
-              <Guess guess={$keyboard} answerLength={$game.answerLength} />
-            {:else}
-              <Guess answerLength={$game.answerLength} />
-            {/if}
-          {/each}
-        </div>
-      {/each}
-    </div>
-  {/each}
+              {#if guessIndex < wordle.guessResults.length}
+                <Guess
+                  guess={wordle.guessResults[guessIndex]}
+                  answerLength={$game.answerLength}
+                />
+              {:else if wordle.status === 'playing' && guessIndex === wordle.guessResults.length}
+                <Guess guess={$keyboard} answerLength={$game.answerLength} />
+              {:else}
+                <Guess answerLength={$game.answerLength} />
+              {/if}
+            {/each}
+          </div>
+        {/each}
+      </div>
+    {/each}
+  </div>
+
+  <Keyboard on:submit={submitGuess} />
 </div>
-
-<Keyboard on:submit={submitGuess} />

--- a/src/components/wordle/Guess.svelte
+++ b/src/components/wordle/Guess.svelte
@@ -80,7 +80,7 @@
 <div class="tw-inline-flex tw-gap-1 tw-min-w-0 tw-min-h-0">
   {#each { length: answerLength } as _, i}
     <div
-      class="tw-w-16 tw-aspect-square tw-border-2 tw-rounded-lg tw-border-solid tw-border-app-text-secondary tw-overflow-hidden"
+      class="tw-w-14 md:tw-w-16 tw-aspect-square tw-border-2 tw-rounded-lg tw-border-solid tw-border-app-text-secondary tw-overflow-hidden"
     >
       {#await drawables then d}
         {#if i < d.length}

--- a/src/components/wordle/keyboard/InputForm.svelte
+++ b/src/components/wordle/keyboard/InputForm.svelte
@@ -24,7 +24,7 @@
     bind:value
     on:focus
     on:blur
-    class="tw-px-2 tw-py-1 tw-rounded-lg tw-text-app-text tw-bg-transparent tw-border tw-border-app-text-secondary tw-shadow"
+    class="tw-w-full tw-px-2 tw-py-1 tw-rounded-lg tw-text-app-text tw-bg-transparent tw-border tw-border-app-text-secondary tw-shadow"
     disabled={$game.status !== 'playing'}
   />
 </form>

--- a/src/components/wordle/keyboard/Key.svelte
+++ b/src/components/wordle/keyboard/Key.svelte
@@ -13,11 +13,11 @@
 
   function getWidth(): string {
     if (size === 'compact') {
-      return 'tw-w-6'
+      return 'tw-w-5 md:tw-w-5 lg:tw-w-6'
     } else if (size === 'wide') {
-      return 'tw-w-16'
+      return 'tw-w-12 md:tw-w-14 lg:tw-w-16'
     } else {
-      return 'tw-w-12'
+      return 'tw-w-10 md:tw-w-10 lg:tw-w-12'
     }
   }
 
@@ -42,12 +42,12 @@
 </script>
 
 <button
-  class="{width} tw-h-14 tw-rounded tw-bg-app-keyboard-bg tw-relative tw-overflow-hidden"
+  class="{width} tw-h-11 md:tw-h-12 lg:tw-h-14 tw-rounded tw-bg-app-keyboard-bg tw-relative tw-overflow-hidden"
   on:click
   {disabled}
 >
   <div
-    class="tw-w-full tw-h-full tw-absolute tw-top-0 tw-text-lg tw-font-bold {textColor} tw-bg-transparent tw-flex tw-flex-nowrap tw-justify-center tw-items-center"
+    class="tw-w-full tw-h-full tw-absolute tw-top-0 md:tw-text-lg tw-font-bold {textColor} tw-bg-transparent tw-flex tw-flex-nowrap tw-justify-center tw-items-center"
   >
     <slot>{key}</slot>
   </div>

--- a/src/components/wordle/keyboard/Keyboard.svelte
+++ b/src/components/wordle/keyboard/Keyboard.svelte
@@ -65,9 +65,9 @@
   })
 </script>
 
-<div class="tw-container">
+<div class="tw-w-full">
   {#if $config.showInputForm}
-    <div class="tw-flex tw-flex-nowrap tw-justify-center tw-mb-6">
+    <div class="tw-flex tw-flex-nowrap tw-justify-center tw-my-1.5 md:tw-my-3">
       <InputForm
         on:submit
         on:focus={() => (isFormFocused = true)}
@@ -77,7 +77,7 @@
   {/if}
 
   <div
-    class="tw-flex tw-flex-nowrap tw-justify-center tw-gap-1.5 tw-mx-2 tw-my-1.5"
+    class="tw-flex tw-flex-nowrap tw-justify-center tw-gap-1.5 tw-mx-2 tw-my-1.5 md:tw-mt-3"
   >
     {#each row1Left as key}
       <Key {key} on:click={() => onClick(key)} />


### PR DESCRIPTION
- Make keyboard and wordle guesses smaller on low res screens
  - Add CSS for responsive design
- Improve visibility when the wordle guesses overflow screen height
  - Keep keyboard at the bottom of the screen
  - Enable vertical scroll on wordle guesses

Close #4 
