### PR TITLE
Improve scrolling in mobile environment

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -23,6 +23,8 @@
 
 <Nav />
 
-<main class="tw-w-full tw-mx-auto tw-py-1 tw-h-[calc(100%-var(--nav-height))]">
+<main
+  class="tw-w-full tw-h-[calc(100%-var(--nav-height))] tw-overflow-y-auto tw-overscroll-y-none"
+>
   <Router {routes} />
 </main>

--- a/src/app.css
+++ b/src/app.css
@@ -56,7 +56,9 @@ body {
   width: 100%;
   height: 100%;
 
+  overflow: hidden;
   touch-action: manipulation;
+  overscroll-behavior-y: none;
 }
 
 body {

--- a/src/components/wordle/Game.svelte
+++ b/src/components/wordle/Game.svelte
@@ -55,12 +55,12 @@
 <div
   class="tw-container tw-min-h-full tw-mx-auto tw-flex tw-flex-nowrap tw-flex-col"
 >
-  <div class="tw-my-auto tw-py-1.5 md:tw-py-3">
+  <div class="tw-my-auto tw-py-1.5 md:tw-py-3 tw-mx-2">
     {#each { length: $ui.nRows } as _, rowIndex}
       <div class={$ui.nRows > 1 ? 'tw-mb-4 md:tw-mb-6' : ''}>
         {#each { length: $game.nGuesses } as _, guessIndex}
           <div
-            class="tw-flex tw-flex-nowrap tw-justify-center tw-gap-4 tw-mx-2 tw-my-1"
+            class="tw-flex tw-flex-nowrap tw-justify-center tw-gap-4 tw-my-1"
           >
             {#each { length: ui.nWordlesAtRow(rowIndex) } as _, colIndex}
               {@const wordleIndex = $ui.nWordlesPerRow * rowIndex + colIndex}
@@ -83,7 +83,7 @@
     {/each}
   </div>
 
-  <div class="tw-w-full tw-sticky tw-bottom-0 tw-bg-app-bg">
+  <div class="tw-sticky tw-bottom-0 tw-mx-2 tw-bg-app-bg">
     <Keyboard on:submit={submitGuess} />
   </div>
 </div>

--- a/src/components/wordle/Game.svelte
+++ b/src/components/wordle/Game.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import Guess from './Guess.svelte'
-  import Alert from './Notification.svelte'
+  import Notification from './Notification.svelte'
   import { openStatsModal } from './Statistics.svelte'
   import Keyboard from './keyboard/Keyboard.svelte'
   import {
@@ -52,14 +52,10 @@
   assert()
 </script>
 
-<div class="tw-flex tw-flex-nowrap tw-justify-center">
-  <Alert />
-</div>
-
 <div
-  class="tw-w-full tw-h-full tw-inline-flex tw-flex-col tw-overflow-y-hidden"
+  class="tw-container tw-min-h-full tw-mx-auto tw-flex tw-flex-nowrap tw-flex-col"
 >
-  <div class="tw-my-auto tw-py-1.5 md:tw-py-3 tw-overflow-y-auto">
+  <div class="tw-my-auto tw-py-1.5 md:tw-py-3">
     {#each { length: $ui.nRows } as _, rowIndex}
       <div class={$ui.nRows > 1 ? 'tw-mb-4 md:tw-mb-6' : ''}>
         {#each { length: $game.nGuesses } as _, guessIndex}
@@ -87,5 +83,13 @@
     {/each}
   </div>
 
-  <Keyboard on:submit={submitGuess} />
+  <div class="tw-w-full tw-sticky tw-bottom-0 tw-bg-app-bg">
+    <Keyboard on:submit={submitGuess} />
+  </div>
+</div>
+
+<div
+  class="tw-w-full tw-fixed tw-top-7 tw-flex tw-flex-nowrap tw-justify-center"
+>
+  <Notification />
 </div>

--- a/src/components/wordle/Notification.svelte
+++ b/src/components/wordle/Notification.svelte
@@ -39,7 +39,7 @@
 
 {#if message}
   <div
-    class="tw-absolute tw-w-full tw-max-w-xs tw-px-3 tw-py-1.5 tw-rounded-lg tw-bg-app-alert-bg tw-shadow-md tw-inline-flex tw-items-center"
+    class="tw-max-w-md tw-px-3 tw-py-1.5 tw-rounded-lg tw-bg-app-alert-bg tw-shadow-md tw-inline-flex tw-items-center"
     role="alert"
   >
     {#if type === 'win'}

--- a/src/components/wordle/keyboard/Keyboard.svelte
+++ b/src/components/wordle/keyboard/Keyboard.svelte
@@ -76,7 +76,7 @@
 {/if}
 
 <div
-  class="tw-flex tw-flex-nowrap tw-justify-center tw-gap-1.5 tw-mx-2 tw-my-1.5 md:tw-mt-3"
+  class="tw-flex tw-flex-nowrap tw-justify-center tw-gap-1.5 tw-my-1.5 md:tw-mt-3"
 >
   {#each row1Left as key}
     <Key {key} on:click={() => onClick(key)} />
@@ -89,17 +89,13 @@
   {/each}
 </div>
 
-<div
-  class="tw-flex tw-flex-nowrap tw-justify-center tw-gap-1.5 tw-mx-2 tw-my-1.5"
->
+<div class="tw-flex tw-flex-nowrap tw-justify-center tw-gap-1.5 tw-my-1.5">
   {#each row2 as key}
     <Key {key} on:click={() => onClick(key)} />
   {/each}
 </div>
 
-<div
-  class="tw-flex tw-flex-nowrap tw-justify-center tw-gap-1.5 tw-mx-2 tw-my-1.5"
->
+<div class="tw-flex tw-flex-nowrap tw-justify-center tw-gap-1.5 tw-my-1.5">
   <Key key="dummy" size="compact" disabled />
   {#each row3 as key}
     <Key {key} on:click={() => onClick(key)} />
@@ -107,9 +103,7 @@
   <Key key="dummy" size="compact" disabled />
 </div>
 
-<div
-  class="tw-flex tw-flex-nowrap tw-justify-center tw-gap-1.5 tw-mx-2 tw-my-1.5"
->
+<div class="tw-flex tw-flex-nowrap tw-justify-center tw-gap-1.5 tw-my-1.5">
   {#if !$config.switchEnterAndBackspacePosition}
     <Key
       key={ENTER_KEY}

--- a/src/components/wordle/keyboard/Keyboard.svelte
+++ b/src/components/wordle/keyboard/Keyboard.svelte
@@ -65,90 +65,88 @@
   })
 </script>
 
-<div class="tw-w-full">
-  {#if $config.showInputForm}
-    <div class="tw-flex tw-flex-nowrap tw-justify-center tw-my-1.5 md:tw-my-3">
-      <InputForm
-        on:submit
-        on:focus={() => (isFormFocused = true)}
-        on:blur={() => (isFormFocused = false)}
-      />
-    </div>
+{#if $config.showInputForm}
+  <div class="tw-flex tw-flex-nowrap tw-justify-center tw-my-1.5 md:tw-my-3">
+    <InputForm
+      on:submit
+      on:focus={() => (isFormFocused = true)}
+      on:blur={() => (isFormFocused = false)}
+    />
+  </div>
+{/if}
+
+<div
+  class="tw-flex tw-flex-nowrap tw-justify-center tw-gap-1.5 tw-mx-2 tw-my-1.5 md:tw-mt-3"
+>
+  {#each row1Left as key}
+    <Key {key} on:click={() => onClick(key)} />
+  {/each}
+  {#each { length: row2.length - row1Left.length - row1Right.length } as _}
+    <Key key="dummy" disabled />
+  {/each}
+  {#each row1Right as key}
+    <Key {key} on:click={() => onClick(key)} />
+  {/each}
+</div>
+
+<div
+  class="tw-flex tw-flex-nowrap tw-justify-center tw-gap-1.5 tw-mx-2 tw-my-1.5"
+>
+  {#each row2 as key}
+    <Key {key} on:click={() => onClick(key)} />
+  {/each}
+</div>
+
+<div
+  class="tw-flex tw-flex-nowrap tw-justify-center tw-gap-1.5 tw-mx-2 tw-my-1.5"
+>
+  <Key key="dummy" size="compact" disabled />
+  {#each row3 as key}
+    <Key {key} on:click={() => onClick(key)} />
+  {/each}
+  <Key key="dummy" size="compact" disabled />
+</div>
+
+<div
+  class="tw-flex tw-flex-nowrap tw-justify-center tw-gap-1.5 tw-mx-2 tw-my-1.5"
+>
+  {#if !$config.switchEnterAndBackspacePosition}
+    <Key
+      key={ENTER_KEY}
+      size="wide"
+      on:click={() => onClick(ENTER_KEY)}
+      on:submit
+    >
+      입력
+    </Key>
+    {#each row4 as key}
+      <Key {key} on:click={() => onClick(key)} />
+    {/each}
+    <Key
+      key={BACKSPACE_KEY}
+      size="wide"
+      on:click={() => onClick(BACKSPACE_KEY)}
+    >
+      <BackspaceIcon />
+    </Key>
+  {:else}
+    <Key
+      key={BACKSPACE_KEY}
+      size="wide"
+      on:click={() => onClick(BACKSPACE_KEY)}
+    >
+      <BackspaceIcon />
+    </Key>
+    {#each row4 as key}
+      <Key {key} on:click={() => onClick(key)} />
+    {/each}
+    <Key
+      key={ENTER_KEY}
+      size="wide"
+      on:click={() => onClick(ENTER_KEY)}
+      on:submit
+    >
+      입력
+    </Key>
   {/if}
-
-  <div
-    class="tw-flex tw-flex-nowrap tw-justify-center tw-gap-1.5 tw-mx-2 tw-my-1.5 md:tw-mt-3"
-  >
-    {#each row1Left as key}
-      <Key {key} on:click={() => onClick(key)} />
-    {/each}
-    {#each { length: row2.length - row1Left.length - row1Right.length } as _}
-      <Key key="dummy" disabled />
-    {/each}
-    {#each row1Right as key}
-      <Key {key} on:click={() => onClick(key)} />
-    {/each}
-  </div>
-
-  <div
-    class="tw-flex tw-flex-nowrap tw-justify-center tw-gap-1.5 tw-mx-2 tw-my-1.5"
-  >
-    {#each row2 as key}
-      <Key {key} on:click={() => onClick(key)} />
-    {/each}
-  </div>
-
-  <div
-    class="tw-flex tw-flex-nowrap tw-justify-center tw-gap-1.5 tw-mx-2 tw-my-1.5"
-  >
-    <Key key="dummy" size="compact" disabled />
-    {#each row3 as key}
-      <Key {key} on:click={() => onClick(key)} />
-    {/each}
-    <Key key="dummy" size="compact" disabled />
-  </div>
-
-  <div
-    class="tw-flex tw-flex-nowrap tw-justify-center tw-gap-1.5 tw-mx-2 tw-my-1.5"
-  >
-    {#if !$config.switchEnterAndBackspacePosition}
-      <Key
-        key={ENTER_KEY}
-        size="wide"
-        on:click={() => onClick(ENTER_KEY)}
-        on:submit
-      >
-        입력
-      </Key>
-      {#each row4 as key}
-        <Key {key} on:click={() => onClick(key)} />
-      {/each}
-      <Key
-        key={BACKSPACE_KEY}
-        size="wide"
-        on:click={() => onClick(BACKSPACE_KEY)}
-      >
-        <BackspaceIcon />
-      </Key>
-    {:else}
-      <Key
-        key={BACKSPACE_KEY}
-        size="wide"
-        on:click={() => onClick(BACKSPACE_KEY)}
-      >
-        <BackspaceIcon />
-      </Key>
-      {#each row4 as key}
-        <Key {key} on:click={() => onClick(key)} />
-      {/each}
-      <Key
-        key={ENTER_KEY}
-        size="wide"
-        on:click={() => onClick(ENTER_KEY)}
-        on:submit
-      >
-        입력
-      </Key>
-    {/if}
-  </div>
 </div>

--- a/src/routes/FontViewer.svelte
+++ b/src/routes/FontViewer.svelte
@@ -47,27 +47,25 @@
   loadSyllables()
 </script>
 
-<div class="tw-w-full tw-inline-flex tw-justify-center">
-  <div class="tw-container tw-flex tw-flex-col tw-gap-4">
-    <div class="tw-flex tw-flex-wrap tw-gap-1">
-      {#each jamoList as jamo}
-        <div
-          class="tw-w-16 tw-h-16 tw-border-2 tw-rounded-lg tw-border-solid tw-border-app-text-secondary"
-        >
-          <Syllable drawable={jamo} />
-        </div>
-      {/each}
-    </div>
-    <div class="tw-flex tw-flex-wrap tw-gap-1">
-      {#each syllableList as syllable}
-        <div
-          class="tw-w-16 tw-h-16 tw-border-2 tw-rounded-lg tw-border-solid tw-border-app-text-secondary"
-        >
-          <Syllable drawable={syllable} {syllableColors} />
-        </div>
-      {/each}
+<div class="tw-container tw-mx-auto tw-py-3">
+  <div class="tw-flex tw-flex-wrap tw-gap-1">
+    {#each jamoList as jamo}
+      <div
+        class="tw-w-16 tw-h-16 tw-border-2 tw-rounded-lg tw-border-solid tw-border-app-text-secondary"
+      >
+        <Syllable drawable={jamo} />
+      </div>
+    {/each}
+  </div>
+  <div class="tw-mt-3 tw-flex tw-flex-wrap tw-gap-1">
+    {#each syllableList as syllable}
+      <div
+        class="tw-w-16 tw-h-16 tw-border-2 tw-rounded-lg tw-border-solid tw-border-app-text-secondary"
+      >
+        <Syllable drawable={syllable} {syllableColors} />
+      </div>
+    {/each}
 
-      <div use:inView on:enter={() => loadSyllables()} />
-    </div>
+    <div use:inView on:enter={() => loadSyllables()} />
   </div>
 </div>

--- a/src/routes/Home.svelte
+++ b/src/routes/Home.svelte
@@ -24,9 +24,7 @@
   ] as const
 </script>
 
-<div
-  class="tw-w-full tw-flex tw-flex-col tw-flex-nowrap tw-items-center tw-gap-8"
->
+<div class="tw-container tw-mx-auto tw-py-3">
   <div
     class="tw-flex tw-flex-nowrap tw-justify-center tw-text-lg tw-font-medium"
   >
@@ -46,7 +44,9 @@
     </div>
   </div>
 
-  <div class="tw-flex tw-flex-wrap tw-justify-center tw-items-stretch tw-gap-3">
+  <div
+    class="tw-mt-6 tw-flex tw-flex-wrap tw-justify-center tw-items-stretch tw-gap-3"
+  >
     {#if $gameMode !== 'custom'}
       {#each GAMES.filter((game) => game.mode === $gameMode) as game}
         <LinkButton url={game.link} useRouter underline={false}>

--- a/src/routes/WordViewer.svelte
+++ b/src/routes/WordViewer.svelte
@@ -66,66 +66,64 @@
   $: words = filterByChars(Wordle.getWordList(length), search)
 </script>
 
-<div class="tw-w-full tw-inline-flex tw-justify-center">
-  <div class="tw-container">
-    <form
-      on:submit|preventDefault
-      class="tw-my-4 tw-flex tw-flex-wrap tw-gap-4 tw-justify-center"
-    >
-      <Select
-        title="Word Length"
-        options={lengths.map((length) => {
-          return { id: length, text: length.toString() }
-        })}
-        on:select={(event) => (length = event.detail.id)}
+<div class="tw-container tw-mx-auto tw-py-3">
+  <form
+    on:submit|preventDefault
+    class="tw-flex tw-flex-wrap tw-gap-4 tw-justify-center"
+  >
+    <Select
+      title="Word Length"
+      options={lengths.map((length) => {
+        return { id: length, text: length.toString() }
+      })}
+      on:select={(event) => (length = event.detail.id)}
+    />
+
+    <div>
+      <label for="search" class="tw-block tw-mb-1 tw-text-sm tw-font-medium">
+        Filter (OR search for each char)
+      </label>
+      <input
+        id="search"
+        type="text"
+        bind:value={search}
+        class="tw-block tw-px-2 tw-py-0.5 tw-rounded-lg tw-bg-app-bg tw-border tw-border-app-text-secondary"
       />
+    </div>
+  </form>
 
-      <div>
-        <label for="search" class="tw-block tw-mb-1 tw-text-sm tw-font-medium">
-          Filter (OR search for each char)
-        </label>
-        <input
-          id="search"
-          type="text"
-          bind:value={search}
-          class="tw-block tw-px-2 tw-py-0.5 tw-rounded-lg tw-bg-app-bg tw-border tw-border-app-text-secondary"
-        />
-      </div>
-    </form>
-
-    <div class="tw-flex tw-gap-6">
+  <div class="tw-mt-3 tw-flex tw-gap-6">
+    <div
+      class="tw-w-1/2 tw-text-center tw-border tw-border-app-text-secondary tw-rounded-lg"
+    >
       <div
-        class="tw-w-1/2 tw-text-center tw-border tw-border-app-text-secondary tw-rounded-lg"
+        class="tw-p-1 tw-font-medium tw-border-b tw-border-app-text-secondary"
       >
-        <div
-          class="tw-p-1 tw-font-medium tw-border-b tw-border-app-text-secondary"
-        >
-          Answers
-        </div>
-        <div class="tw-p-1 tw-flex tw-flex-wrap tw-text-sm">
-          {#each answers.slice(0, answerPage * loadSize) as answer}
-            <span class="tw-m-1">{answer}</span>
-          {/each}
-
-          <div use:inView on:enter={() => loadAnswers()} />
-        </div>
+        Answers
       </div>
+      <div class="tw-p-1 tw-flex tw-flex-wrap tw-text-sm">
+        {#each answers.slice(0, answerPage * loadSize) as answer}
+          <span class="tw-m-1">{answer}</span>
+        {/each}
 
+        <div use:inView on:enter={() => loadAnswers()} />
+      </div>
+    </div>
+
+    <div
+      class="tw-w-1/2 tw-text-center tw-border tw-border-app-text-secondary tw-rounded-lg"
+    >
       <div
-        class="tw-w-1/2 tw-text-center tw-border tw-border-app-text-secondary tw-rounded-lg"
+        class="tw-p-1 tw-font-medium tw-border-b tw-border-app-text-secondary"
       >
-        <div
-          class="tw-p-1 tw-font-medium tw-border-b tw-border-app-text-secondary"
-        >
-          Words
-        </div>
-        <div class="tw-p-1 tw-flex tw-flex-wrap tw-text-sm">
-          {#each words.slice(0, wordPage * loadSize) as word}
-            <span class="tw-m-1">{word}</span>
-          {/each}
+        Words
+      </div>
+      <div class="tw-p-1 tw-flex tw-flex-wrap tw-text-sm">
+        {#each words.slice(0, wordPage * loadSize) as word}
+          <span class="tw-m-1">{word}</span>
+        {/each}
 
-          <div use:inView on:enter={() => loadWords()} />
-        </div>
+        <div use:inView on:enter={() => loadWords()} />
       </div>
     </div>
   </div>


### PR DESCRIPTION
- Disable pull-to-refresh
- Add `overscroll-behavior` css which is supported in modern browsers
- Enable guess area scrolling even if the focus is in the keyboard UI, by making the keyboard UI a sticky element
  - From this change, the scroll bar became visible on the guess UI and the keyboard UI.
    However, in Safari browser, the scrollbar is placed behind the sticky UI.
    This problem is handled by adding small margin-x in the sticky keyboard UI, assuming the scrollbar width is smaller than the margin in various environments (checked in Safari, iOS 15.7)
- Simplify container on some pages

Close #6
